### PR TITLE
Update the view when the next button is clicked

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,8 @@ var cols *ResizeableColumnsWidget
 var rows1 *ResizeablePileWidget
 var rows2 *ResizeablePileWidget
 var vimWidget *terminal.Widget
+var viewHolder *holder.Widget
+
 //var controller *exerciseController
 //var view *exerciseView
 //var yesno *dialog.Widget
@@ -276,11 +278,12 @@ func makeNewMenuWidget() *menuWidget {
 }
 //============ Exercise View ================================================
 type exerciseView struct {
-	view *framed.Widget
-	title *text.Widget
-	titleInv *styled.Widget
-	holder *holder.Widget
-	vimWidget *terminal.Widget
+	viewHolder *holder.Widget
+	view       *framed.Widget
+	title      *text.Widget
+	titleInv   *styled.Widget
+	holder     *holder.Widget
+	vimWidget  *terminal.Widget
 	menuWidget *menuWidget
 }
 
@@ -398,8 +401,7 @@ func makeNewExerciseController() (*exerciseController,error) {
 	// === setting button controls ===
 	res.view.menuWidget.nextBt.OnClick(gowid.WidgetCallback{"cb", func(app gowid.IApp, w gowid.IWidget) {
 		view, _ := makeNewExerciseView()
-		res.view = view
-		app.Redraw()
+		viewHolder.SetSubWidget(view.view, app)
 	}})
 
 	res.view.menuWidget.exitBt.OnClick(gowid.WidgetCallback{"cb", func(app gowid.IApp, w gowid.IWidget) {
@@ -425,8 +427,10 @@ func main() {
 
 	controller, err := makeNewExerciseController()
 
+	viewHolder = holder.New(controller.view.view)
+
 	app, err = gowid.NewApp(gowid.AppArgs{
-		View:    controller.view.view,
+		View:    viewHolder,
 		Palette: &palette,
 		Log:     log.StandardLogger(),
 	})


### PR DESCRIPTION
Hi @nickw8 - I've made a few small tweaks to your program so that your
view updates when the next button is clicked. The issue was that the
"app" has a pointer to the original view you set up, view the "View:"
parameter to its constructor, so updating res.view in the next-button
callback won't make changes to the app's widget hierarchy. The way I
fixed this was to change your app constructor call so that the root of
the widget hierarchy is a *holder.Widget, and then to update the
contents of the holder inside the callback.

While debugging, I found a problem inside gowid itself! My intention was
that the "app" itself should support the SetSubWidget() call as a way to
directly change the root of the widget hierarchy; but I seem to have
broken that with some complications I added around supporting menus. So
for now, this approach will work fine, and soon I'll push a gowid update
that makes SetSubWidget() work again.

This change doesn't make everything work, though. The callbacks on the
buttons are set up via "res.view.menuWidget.nextBt.OnClick(...)" when
building the controller, but when next is clicked and a new view is
created, the view contains new button widgets and they don't have these
callbacks attached. Perhaps the button callbacks could be added when the
view is built? This may be polluting your separation of view and
controller - not sure how you feel about that.

Another thing you might have to do is close the vim process when the
view is switched, to make sure processes don't accumulate. There is a
method on the terminal.Widget called StopCommand() that should do the
job.